### PR TITLE
Ensures identical IndexMetadata across all nodes to prevent coordination failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,12 +71,6 @@ The cluster-etcd plugin now uses a split metadata approach that separates index 
 
 This approach reduces etcd storage requirements and simplifies control plane logic by filtering out data plane implementation details.
 
-#### Automatic UUID and Version Generation
-
-The plugin now automatically generates index metadata constants programmatically rather than storing them in etcd
-
-This eliminates the need to manually specify these values in etcd and ensures all nodes maintain identical metadata, preventing cluster coordination failures due to hashcode mismatches.
-
 ```bash
 # Write index settings and mappings separately (new split metadata approach)
 # Settings are needed by both data nodes and coordinators

--- a/README.md
+++ b/README.md
@@ -73,11 +73,7 @@ This approach reduces etcd storage requirements and simplifies control plane log
 
 #### Automatic UUID and Version Generation
 
-The plugin now automatically generates index metadata constants programmatically rather than storing them in etcd:
-
-- **UUID**: Generated deterministically from the index name using UUID.nameUUIDFromBytes(), ensuring all nodes produce identical UUIDs for the same index
-- **Version**: Set to the current OpenSearch version (Version.CURRENT)
-- **Creation Date**: Generated deterministically from the index name to ensure consistency across nodes
+The plugin now automatically generates index metadata constants programmatically rather than storing them in etcd
 
 This eliminates the need to manually specify these values in etcd and ensures all nodes maintain identical metadata, preventing cluster coordination failures due to hashcode mismatches.
 

--- a/src/main/java/org/opensearch/cluster/etcd/ETCDHeartbeat.java
+++ b/src/main/java/org/opensearch/cluster/etcd/ETCDHeartbeat.java
@@ -39,6 +39,11 @@ import org.opensearch.cluster.routing.ShardRouting;
 import java.util.List;
 import java.util.ArrayList;
 
+/**
+ * Service responsible for publishing heartbeat and health information to etcd.
+ * Each node periodically publishes its status, health metrics, and shard information
+ * to allow other nodes and external systems to monitor cluster health.
+ */
 public class ETCDHeartbeat {
     private static final long HEARTBEAT_INTERVAL_SECONDS = 5;
     private final Logger logger = LogManager.getLogger(getClass());
@@ -53,6 +58,14 @@ public class ETCDHeartbeat {
     private final NodeEnvironment nodeEnvironment;
     private final ClusterService clusterService;
 
+    /**
+     * Creates a new ETCDHeartbeat service.
+     *
+     * @param localNode       the local discovery node
+     * @param etcdClient      the etcd client for publishing heartbeat data
+     * @param nodeEnvironment the node environment for accessing local node information
+     * @param clusterService  the cluster service for accessing cluster state
+     */
     public ETCDHeartbeat(DiscoveryNode localNode, Client etcdClient, NodeEnvironment nodeEnvironment, ClusterService clusterService) {
         this.nodeName = localNode.getName();
         this.nodeId = localNode.getId();
@@ -72,10 +85,16 @@ public class ETCDHeartbeat {
         return Executors.newSingleThreadScheduledExecutor(r -> new Thread(r, "etcd-heartbeat-scheduler"));
     }
 
+    /**
+     * Starts the heartbeat service, beginning periodic publication of node health data to etcd.
+     */
     public void start() {
         scheduler.scheduleAtFixedRate(this::publishHeartbeat, 0, HEARTBEAT_INTERVAL_SECONDS, TimeUnit.SECONDS);
     }
 
+    /**
+     * Stops the heartbeat service and shuts down the scheduler.
+     */
     public void stop() {
         scheduler.shutdown();
         try {

--- a/src/main/java/org/opensearch/cluster/etcd/ETCDIndexMetadataPublisher.java
+++ b/src/main/java/org/opensearch/cluster/etcd/ETCDIndexMetadataPublisher.java
@@ -38,6 +38,12 @@ public class ETCDIndexMetadataPublisher {
     private final Client etcdClient;
     private final String clusterName;
 
+    /**
+     * Creates a new ETCDIndexMetadataPublisher.
+     *
+     * @param etcdClient  the etcd client for publishing metadata
+     * @param clusterName the cluster name for building etcd paths
+     */
     public ETCDIndexMetadataPublisher(Client etcdClient, String clusterName) {
         this.etcdClient = etcdClient;
         this.clusterName = clusterName;

--- a/src/main/java/org/opensearch/cluster/etcd/ETCDIndexMetadataPublisher.java
+++ b/src/main/java/org/opensearch/cluster/etcd/ETCDIndexMetadataPublisher.java
@@ -168,17 +168,16 @@ public class ETCDIndexMetadataPublisher {
     
     /**
      * Determines if a setting should be filtered out (not stored in etcd) because
-     * it's populated as a constant in the plugin. This is critical for preventing
-     * hashcode mismatches that cause cluster coordination failures.
+     * it's populated as a constant in the plugin. 
      */
     private boolean shouldFilterOutSetting(String settingKey) {
         // Filter out settings that are generated programmatically in the plugin
         // to enable stateless node operation. All filtered settings MUST be generated
         // deterministically to ensure identical IndexMetadata across all nodes.
         switch (settingKey) {
-            case "index.uuid":  // IndexMetadata.SETTING_INDEX_UUID - deterministic based on index name
-            case "index.version.created":  // IndexMetadata.SETTING_VERSION_CREATED - always Version.CURRENT
-            case "index.creation_date":  // IndexMetadata.SETTING_CREATION_DATE - deterministic based on index name
+            case "index.uuid":  
+            case "index.version.created":  
+            case "index.creation_date":  
                 return true;
             default:
                 return false;

--- a/src/main/java/org/opensearch/cluster/etcd/ETCDPathUtils.java
+++ b/src/main/java/org/opensearch/cluster/etcd/ETCDPathUtils.java
@@ -14,19 +14,46 @@ package org.opensearch.cluster.etcd;
  */
 public class ETCDPathUtils {
     
+    /**
+     * Builds the etcd path for search unit configuration.
+     *
+     * @param clusterName the cluster name
+     * @param searchName  the search unit name
+     * @return the etcd path for search unit configuration
+     */
     public static String buildSearchUnitConfigPath(String clusterName, String searchName) {
         return clusterName + "/search-unit/" + searchName + "/conf";
     }
     
-   
+    /**
+     * Builds the etcd path for search unit goal state.
+     *
+     * @param clusterName the cluster name
+     * @param searchName  the search unit name
+     * @return the etcd path for search unit goal state
+     */
     public static String buildSearchUnitGoalStatePath(String clusterName, String searchName) {
         return clusterName + "/search-unit/" + searchName + "/goal-state";
     }
     
+    /**
+     * Builds the etcd path for search unit actual state.
+     *
+     * @param clusterName the cluster name
+     * @param searchName  the search unit name
+     * @return the etcd path for search unit actual state
+     */
     public static String buildSearchUnitActualStatePath(String clusterName, String searchName) {
         return clusterName + "/search-unit/" + searchName + "/actual-state";
     }
     
+    /**
+     * Builds the etcd path for node actual state (heartbeat information).
+     *
+     * @param clusterName the cluster name
+     * @param nodeName    the node name
+     * @return the etcd path for node actual state
+     */
     public static String buildNodeActualStatePath(String clusterName, String nodeName) {
         return buildSearchUnitActualStatePath(clusterName, nodeName);
     }
@@ -34,6 +61,10 @@ public class ETCDPathUtils {
     /**
      * @deprecated Use buildIndexSettingsPath, buildIndexMappingsPath, or buildIndexOtherPath instead.
      * This method returns the legacy path for complete index metadata blob.
+     *
+     * @param clusterName the cluster name
+     * @param indexName   the index name
+     * @return the etcd path for complete index configuration (deprecated)
      */
     @Deprecated
     public static String buildIndexConfigPath(String clusterName, String indexName) {
@@ -64,11 +95,26 @@ public class ETCDPathUtils {
         return clusterName + "/indices/" + indexName + "/mappings";
     }
     
+    /**
+     * Builds the etcd path for planned shard allocation.
+     *
+     * @param clusterName the cluster name
+     * @param indexName   the index name
+     * @param shardId     the shard ID
+     * @return the etcd path for planned shard allocation
+     */
     public static String buildShardPlannedAllocationPath(String clusterName, String indexName, int shardId) {
         return clusterName + "/indices/" + indexName + "/shard/" + shardId + "/planned-allocation";
     }
     
-   
+    /**
+     * Builds the etcd path for actual shard allocation.
+     *
+     * @param clusterName the cluster name
+     * @param indexName   the index name
+     * @param shardId     the shard ID
+     * @return the etcd path for actual shard allocation
+     */
     public static String buildShardActualAllocationPath(String clusterName, String indexName, int shardId) {
         return clusterName + "/indices/" + indexName + "/shard/" + shardId + "/actual-allocation";
     }

--- a/src/main/java/org/opensearch/cluster/etcd/ETCDStateDeserializer.java
+++ b/src/main/java/org/opensearch/cluster/etcd/ETCDStateDeserializer.java
@@ -313,10 +313,6 @@ public class ETCDStateDeserializer {
     /**
      * Builds IndexMetadata with settings and mappings from etcd, plus constant values 
      * that are populated in the plugin rather than stored in etcd.
-     * 
-     * Basically, all generated constants must be deterministic to prevent hashcode mismatches
-     * between nodes that would cause cluster coordination failures. Each node must generate
-     * identical values for the same index name.
      */
     private static IndexMetadata buildIndexMetadataWithConstants(
         String indexName, 
@@ -329,7 +325,6 @@ public class ETCDStateDeserializer {
             Settings.builder();
       
         // Generate stateless constants programmatically instead of storing in etcd
-        // Generate a deterministic UUID based on index name to ensure consistency across nodes
         String indexUuid = generateDeterministicUUID(indexName);
         settingsBuilder.put(IndexMetadata.SETTING_INDEX_UUID, indexUuid);
         
@@ -367,19 +362,12 @@ public class ETCDStateDeserializer {
      * generate the same UUID for the same index. This replaces storing UUIDs in etcd.
      */
     private static String generateDeterministicUUID(String indexName) {
-        // Generate a deterministic UUID based on index name hash
-        // This ensures all nodes generate the same UUID for the same index
+
         UUID uuid = UUID.nameUUIDFromBytes(indexName.getBytes(StandardCharsets.UTF_8));
-        
-        // Convert to string format that OpenSearch expects
         return uuid.toString();
     }
     
-    /**
-     * Generates a deterministic creation date based on the index name to ensure all nodes
-     * generate the same creation date for the same index. This prevents hashcode mismatches
-     * that would cause cluster coordination failures.
-     */
+
     private static long generateDeterministicCreationDate(String indexName) {
         // Generate a deterministic timestamp based on index name
         // This ensures all nodes generate the same creation date for the same index

--- a/src/main/java/org/opensearch/cluster/etcd/changeapplier/ChangeApplierService.java
+++ b/src/main/java/org/opensearch/cluster/etcd/changeapplier/ChangeApplierService.java
@@ -15,20 +15,42 @@ import org.opensearch.cluster.node.DiscoveryNode;
 import org.opensearch.cluster.node.DiscoveryNodes;
 import org.opensearch.cluster.service.ClusterApplierService;
 
+/**
+ * Service responsible for applying cluster state changes from etcd to the local OpenSearch node.
+ * This service acts as a bridge between the etcd-based cluster state and OpenSearch's internal
+ * cluster state management.
+ */
 public class ChangeApplierService {
     private final Logger logger = LogManager.getLogger(getClass());
     private final ClusterApplierService clusterApplierService;
 
+    /**
+     * Creates a new ChangeApplierService.
+     *
+     * @param clusterApplierService the OpenSearch cluster applier service to delegate to
+     */
     public ChangeApplierService(ClusterApplierService clusterApplierService) {
         this.clusterApplierService = clusterApplierService;
     }
 
+    /**
+     * Applies a new node state to the cluster by building and applying a new cluster state.
+     *
+     * @param source    the source identifier for logging purposes
+     * @param nodeState the new node state to apply
+     */
     public void applyNodeState(String source, NodeState nodeState) {
         clusterApplierService.onNewClusterState(source,
             () -> nodeState.buildClusterState(clusterApplierService.state()),
             this::logError);
     }
 
+    /**
+     * Removes a node from the cluster by resetting to an empty cluster state.
+     *
+     * @param source    the source identifier for logging purposes
+     * @param localNode the local node to keep in the empty cluster state
+     */
     public void removeNode(String source, DiscoveryNode localNode) {
         // Return to empty cluster state
         ClusterState clusterState = ClusterState.builder(ClusterState.EMPTY_STATE)

--- a/src/main/java/org/opensearch/cluster/etcd/changeapplier/CoordinatorNodeState.java
+++ b/src/main/java/org/opensearch/cluster/etcd/changeapplier/CoordinatorNodeState.java
@@ -35,11 +35,23 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+/**
+ * Represents the state of a coordinator node in the etcd-coordinated cluster.
+ * Coordinator nodes are responsible for routing requests to data nodes and
+ * coordinating distributed operations across the cluster.
+ */
 public class CoordinatorNodeState extends NodeState {
 
     private final List<RemoteNode> remoteNodes;
     private final Map<Index, List<List<NodeShardAssignment>>> remoteShardAssignments;
 
+    /**
+     * Creates a new CoordinatorNodeState.
+     *
+     * @param localNode              the local coordinator node
+     * @param remoteNodes            list of remote data nodes that this coordinator manages
+     * @param remoteShardAssignments map of indices to their shard assignments across remote nodes
+     */
     public CoordinatorNodeState(DiscoveryNode localNode, List<RemoteNode> remoteNodes, Map<Index, List<List<NodeShardAssignment>>> remoteShardAssignments) {
         super(localNode);
         this.remoteNodes = remoteNodes;

--- a/src/main/java/org/opensearch/cluster/etcd/changeapplier/DataNodeState.java
+++ b/src/main/java/org/opensearch/cluster/etcd/changeapplier/DataNodeState.java
@@ -26,10 +26,21 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
+/**
+ * Represents the state of a data node in the etcd-coordinated cluster.
+ * Data nodes are responsible for hosting shards and handling indexing/search operations.
+ */
 public class DataNodeState extends NodeState {
     private final Map<String, IndexMetadata> indices;
     private final Map<String, Map<Integer, ShardRole>> assignedShards;
 
+    /**
+     * Creates a new DataNodeState.
+     *
+     * @param localNode      the local data node
+     * @param indices        map of index names to their metadata
+     * @param assignedShards map of index names to shard assignments (shard ID -> role)
+     */
     public DataNodeState(DiscoveryNode localNode, Map<String, IndexMetadata> indices, Map<String, Map<Integer, ShardRole>> assignedShards) {
         super(localNode);
         // The index metadata and shard assignment should be identical

--- a/src/main/java/org/opensearch/cluster/etcd/changeapplier/NodeShardAssignment.java
+++ b/src/main/java/org/opensearch/cluster/etcd/changeapplier/NodeShardAssignment.java
@@ -10,6 +10,9 @@ package org.opensearch.cluster.etcd.changeapplier;
 
 /**
  * Represents the assignment of a shard to a node, from the coordinator's perspective.
+ *
+ * @param nodeId    the unique identifier of the node that should host this shard
+ * @param shardRole the role this shard should play on the node (PRIMARY, REPLICA, or SEARCH_REPLICA)
  */
 public record NodeShardAssignment(String nodeId, ShardRole shardRole) {
 }

--- a/src/main/java/org/opensearch/cluster/etcd/changeapplier/NodeState.java
+++ b/src/main/java/org/opensearch/cluster/etcd/changeapplier/NodeState.java
@@ -11,14 +11,31 @@ package org.opensearch.cluster.etcd.changeapplier;
 import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.node.DiscoveryNode;
 
+/**
+ * Abstract base class representing the state of a node in the etcd-coordinated cluster.
+ * Different node types (coordinator, data nodes) extend this class to provide
+ * specific cluster state building logic.
+ */
 public abstract class NodeState {
+    /** The local node that this state represents */
     protected final DiscoveryNode localNode;
     // TODO: Both coordinator and data nodes might need general metadata (not index metadata)
 
+    /**
+     * Creates a new NodeState for the given local node.
+     *
+     * @param localNode the local discovery node
+     */
     public NodeState(DiscoveryNode localNode) {
         this.localNode = localNode;
     }
 
+    /**
+     * Builds a cluster state based on this node's view of the cluster.
+     *
+     * @param previous the previous cluster state
+     * @return the new cluster state reflecting this node's current state
+     */
     public abstract ClusterState buildClusterState(ClusterState previous);
 
 }

--- a/src/main/java/org/opensearch/cluster/etcd/changeapplier/RemoteNode.java
+++ b/src/main/java/org/opensearch/cluster/etcd/changeapplier/RemoteNode.java
@@ -15,9 +15,10 @@ package org.opensearch.cluster.etcd.changeapplier;
  * TODO: We'll assume that remote node names, IDs, and ephemeral IDs are all the same.
  * Hopefully that won't cause any problems.
  *
- * @param nodeId  the name, ID, and ephemeral ID for the remote node
- * @param address the IP address (IPv4 or IPv6) of the remote node
- * @param port    the port to connect to on the remote node (usually 9300)
+ * @param nodeId     the unique identifier for the remote node
+ * @param ephemeralId the ephemeral ID for the remote node
+ * @param address    the IP address (IPv4 or IPv6) of the remote node
+ * @param port       the port to connect to on the remote node (usually 9300)
  */
 public record RemoteNode(String nodeId, String ephemeralId, String address, int port) {
 }

--- a/src/main/java/org/opensearch/cluster/etcd/changeapplier/ShardRole.java
+++ b/src/main/java/org/opensearch/cluster/etcd/changeapplier/ShardRole.java
@@ -8,8 +8,14 @@
 
 package org.opensearch.cluster.etcd.changeapplier;
 
+/**
+ * Defines the role that a shard can play on a node in the cluster.
+ */
 public enum ShardRole {
+    /** The primary shard that handles indexing and search operations */
     PRIMARY,
+    /** A replica shard that handles search operations and provides redundancy */
     REPLICA,
+    /** A search-only replica that handles search operations but not indexing */
     SEARCH_REPLICA
 }


### PR DESCRIPTION

- **UUID**: Generated deterministically from the index name using UUID.nameUUIDFromBytes(), ensuring all nodes produce identical UUIDs for the same index
- **Version**: Set to the current OpenSearch version (Version.CURRENT)
