### PR TITLE
Set index to "search only" on search replica

### DIFF
--- a/src/main/java/org/opensearch/cluster/etcd/changeapplier/DataNodeState.java
+++ b/src/main/java/org/opensearch/cluster/etcd/changeapplier/DataNodeState.java
@@ -15,6 +15,7 @@ import org.opensearch.cluster.routing.RecoverySource;
 import org.opensearch.cluster.routing.RoutingTable;
 import org.opensearch.cluster.routing.ShardRouting;
 import org.opensearch.cluster.routing.UnassignedInfo;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.core.index.Index;
 import org.opensearch.core.index.shard.ShardId;
 
@@ -78,6 +79,11 @@ public class DataNodeState extends NodeState {
                 }
                 indexRoutingTableBuilder.addShard(shardRouting);
                 indexMetadataBuilder.putInSyncAllocationIds(shardNum, Set.of(shardRouting.allocationId().getId()));
+                if (role == ShardRole.SEARCH_REPLICA) {
+                    Settings.Builder settingsBuilder = Settings.builder().put(indexMetadata.getSettings());
+                    settingsBuilder.put(IndexMetadata.INDEX_BLOCKS_SEARCH_ONLY_SETTING.getKey(), true);
+                    indexMetadataBuilder.settings(settingsBuilder.build());
+                }
             }
             routingTableBuilder.add(indexRoutingTableBuilder);
             metadataBuilder.put(indexMetadataBuilder);


### PR DESCRIPTION
Because of how "cluster health" (red, yellow, green) is calculated, we normally consider it disastrous if a shard has no primary in the routing table. In our clusterless environment, though, it's totally normal for a search replica to live on a node with no reference to the primary in the routing table.

In order to prevent core from panicking, we need to claim that the index is running in "search only" mode, which means that it's okay to have no primary shards.