### PR TITLE
Add node name to heartbeat routing table

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,11 +99,6 @@ afterEvaluate {
   project.validateNebulaPom.enabled = false
 }
 
-
-compileJava {
-    dependsOn spotlessApply
-}
-
 task integTest(type: RestIntegTestTask) {
     description = "Run tests against a cluster"
     testClassesDirs = sourceSets.test.output.classesDirs

--- a/src/main/java/org/opensearch/cluster/etcd/ETCDHeartbeat.java
+++ b/src/main/java/org/opensearch/cluster/etcd/ETCDHeartbeat.java
@@ -204,6 +204,7 @@ public class ETCDHeartbeat {
                     }
                     shardInfo.put("allocationId", shardRouting.allocationId().getId());
                     shardInfo.put("currentNodeId", shardRouting.currentNodeId());
+                    shardInfo.put("currentNodeName", clusterState.nodes().get(shardRouting.currentNodeId()).getName());
                     allShards.add(shardInfo);
                 }
             }

--- a/src/test/java/org/opensearch/cluster/etcd/ETCDHeartbeatTests.java
+++ b/src/test/java/org/opensearch/cluster/etcd/ETCDHeartbeatTests.java
@@ -391,6 +391,7 @@ public class ETCDHeartbeatTests extends OpenSearchTestCase {
                     assertTrue("relocating should be present", shardInfo.containsKey("relocating"));
                     assertTrue("allocationId should be present", shardInfo.containsKey("allocationId"));
                     assertTrue("currentNodeId should be present", shardInfo.containsKey("currentNodeId"));
+                    assertTrue("currentNodeName should be present", shardInfo.containsKey("currentNodeId"));
                 });
 
                 heartbeat.stop();


### PR DESCRIPTION
Controllers don't necessarily understand node IDs -- they're internal to OpenSearch. For now, we're assuming that controllers do understand node names, though, so we should publish our current routing table with node names (in addition to the internal IDs).