### PR TITLE
Retry loading goal state until cluster state converges

### DIFF
--- a/src/main/java/org/opensearch/cluster/etcd/ETCDPathUtils.java
+++ b/src/main/java/org/opensearch/cluster/etcd/ETCDPathUtils.java
@@ -15,10 +15,6 @@ public class ETCDPathUtils {
     private static final String SEARCH_UNIT_GROUP_ATTRIBUTE = "search_unit_group";
     private static final String SEARCH_UNIT_NAME_ATTRIBUTE = "search_unit";
 
-    public static String buildSearchUnitConfigPath(String clusterName, String searchName) {
-        return "/" + clusterName + "/search-unit/" + searchName + "/conf";
-    }
-
     public static String buildSearchUnitGoalStatePath(DiscoveryNode discoveryNode, String clusterName) {
         String searchUnitGroup = discoveryNode.getAttributes().getOrDefault(SEARCH_UNIT_GROUP_ATTRIBUTE, DEFAULT_SEARCH_UNIT_GROUP);
         String searchUnit = discoveryNode.getAttributes().getOrDefault(SEARCH_UNIT_NAME_ATTRIBUTE, discoveryNode.getName());

--- a/src/main/java/org/opensearch/cluster/etcd/changeapplier/CoordinatorNodeState.java
+++ b/src/main/java/org/opensearch/cluster/etcd/changeapplier/CoordinatorNodeState.java
@@ -32,9 +32,10 @@ public class CoordinatorNodeState extends NodeState {
     public CoordinatorNodeState(
         DiscoveryNode localNode,
         Collection<RemoteNode> remoteNodes,
-        Map<Index, List<List<NodeShardAssignment>>> remoteShardAssignments
+        Map<Index, List<List<NodeShardAssignment>>> remoteShardAssignments,
+        boolean converged
     ) {
-        super(localNode);
+        super(localNode, converged);
         this.remoteNodes = remoteNodes;
         this.remoteShardAssignments = remoteShardAssignments;
     }

--- a/src/main/java/org/opensearch/cluster/etcd/changeapplier/DataNodeState.java
+++ b/src/main/java/org/opensearch/cluster/etcd/changeapplier/DataNodeState.java
@@ -31,8 +31,13 @@ public class DataNodeState extends NodeState {
     private final Map<String, IndexMetadata> indices;
     private final Map<String, Set<DataNodeShard>> assignedShards;
 
-    public DataNodeState(DiscoveryNode localNode, Map<String, IndexMetadata> indices, Map<String, Set<DataNodeShard>> assignedShards) {
-        super(localNode);
+    public DataNodeState(
+        DiscoveryNode localNode,
+        Map<String, IndexMetadata> indices,
+        Map<String, Set<DataNodeShard>> assignedShards,
+        boolean converged
+    ) {
+        super(localNode, converged);
         // The index metadata and shard assignment should be identical
         assert indices.keySet().equals(assignedShards.keySet());
         this.indices = indices;

--- a/src/main/java/org/opensearch/cluster/etcd/changeapplier/NodeState.java
+++ b/src/main/java/org/opensearch/cluster/etcd/changeapplier/NodeState.java
@@ -8,13 +8,18 @@ import org.opensearch.cluster.ClusterState;
 import org.opensearch.cluster.node.DiscoveryNode;
 
 public abstract class NodeState {
+    protected final boolean converged;
     protected final DiscoveryNode localNode;
     // TODO: Both coordinator and data nodes might need general metadata (not index metadata)
 
-    public NodeState(DiscoveryNode localNode) {
+    public NodeState(DiscoveryNode localNode, boolean converged) {
         this.localNode = localNode;
+        this.converged = converged;
     }
 
     public abstract ClusterState buildClusterState(ClusterState previous);
 
+    public final boolean hasConverged() {
+        return converged;
+    }
 }

--- a/src/test/java/org/opensearch/cluster/etcd/ETCDWatcherTests.java
+++ b/src/test/java/org/opensearch/cluster/etcd/ETCDWatcherTests.java
@@ -57,7 +57,7 @@ public class ETCDWatcherTests extends OpenSearchTestCase {
         );
 
         MockNodeStateApplier mockNodeStateApplier = new MockNodeStateApplier();
-        String configPath = ETCDPathUtils.buildSearchUnitConfigPath(clusterName, nodeName);
+        String configPath = ETCDPathUtils.buildSearchUnitGoalStatePath(localNode, clusterName);
         try (EtcdCluster etcdCluster = Etcd.builder().withNodes(1).build()) {
             etcdCluster.start();
             try (
@@ -129,7 +129,7 @@ public class ETCDWatcherTests extends OpenSearchTestCase {
         );
 
         MockNodeStateApplier mockNodeStateApplier = new MockNodeStateApplier();
-        String configPath = ETCDPathUtils.buildSearchUnitConfigPath(clusterName, nodeName);
+        String configPath = ETCDPathUtils.buildSearchUnitGoalStatePath(localNode, clusterName);
 
         try (EtcdCluster etcdCluster = Etcd.builder().withNodes(1).build()) {
             etcdCluster.start();


### PR DESCRIPTION


<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
When we rely on status of shards on other nodes to apply goal state, as is the case for document replication, what should we do when those shards don't have the given status?

One option (implemented previously) is to throw an exception, declaring the goal state invalid. Another option (implemented here) is to apply the parts of goal state that we can, and say that we have not converged to the desired goal state. When that happens, we can schedule a reload of the goal state some time later, hoping that the other nodes have made enough progress to allow us to converge.

### Related Issues
Resolves #24 

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
