### PR TITLE
Provide alias support for data plane

### DIFF
--- a/src/main/java/org/opensearch/cluster/etcd/changeapplier/CoordinatorNodeState.java
+++ b/src/main/java/org/opensearch/cluster/etcd/changeapplier/CoordinatorNodeState.java
@@ -134,10 +134,10 @@ public class CoordinatorNodeState extends NodeState {
         for (Map.Entry<String, Object> aliasEntry : aliases.entrySet()) {
             String aliasName = aliasEntry.getKey();
             Object aliasValue = aliasEntry.getValue();
-            
+
             // Check if this alias points to the current index
             if (isAliasForIndex(aliasValue, indexName)) {
-                AliasMetadata.Builder aliasBuilder = AliasMetadata.builder(aliasName);                
+                AliasMetadata.Builder aliasBuilder = AliasMetadata.builder(aliasName);
                 indexMetadataBuilder.putAlias(aliasBuilder.build());
             }
         }
@@ -153,8 +153,7 @@ public class CoordinatorNodeState extends NodeState {
             List<?> indices = (List<?>) aliasValue;
             return indices.contains(indexName);
         }
-        return false; 
+        return false;
     }
-
 
 }

--- a/src/test/java/org/opensearch/cluster/etcd/ETCDWatcherTests.java
+++ b/src/test/java/org/opensearch/cluster/etcd/ETCDWatcherTests.java
@@ -228,7 +228,7 @@ public class ETCDWatcherTests extends OpenSearchTestCase {
                     // Verify remote nodes are in the cluster state
                     assertNotNull(clusterState.nodes().get("remote-node-id-1"));
                     assertNotNull(clusterState.nodes().get("remote-node-id-2"));
-                    
+
                     // Verify aliases are present in the index metadata
                     var indexMetadata = clusterState.metadata().index(indexName);
                     assertTrue(indexMetadata.getAliases().containsKey("logs-current"));


### PR DESCRIPTION
- Added alias support for coordinator nodes - aliases configured in coordinator goal-state and applied to OpenSearch ClusterState
- Supported both simple aliases ("alias": "index") and multi-index aliases ("alias": ["index1", "index2"]) 


E2E Testing completed, results added to runbook