### PR TITLE
Block cluster manager APIs (or route to local)

### DIFF
--- a/src/main/java/org/opensearch/cluster/etcd/ClusterETCDPlugin.java
+++ b/src/main/java/org/opensearch/cluster/etcd/ClusterETCDPlugin.java
@@ -122,6 +122,6 @@ public class ClusterETCDPlugin extends Plugin implements ClusterPlugin, ActionPl
 
     @Override
     public List<ActionFilter> getActionFilters() {
-        return List.of(new ClusterHealthActionFilter(clusterService));
+        return List.of(new ClusterManagerActionFilter(clusterService));
     }
 }


### PR DESCRIPTION


<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Since we don't have cluster managers on clusterless configurations, we should block any mutating request that tries to route to the cluster manager, since that's preferable to hanging on trying to reach the cluster manager.

For read-only requests, we can force the operation to run on the local node, which will usually read from the node's local cluster state.

### Related Issues
Resolves #41 #36

### Check List
- [ ] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
