### PR TITLE
[CN OS] coordinator nodes to support CCS

### DIFF
--- a/src/main/java/org/opensearch/cluster/etcd/ETCDStateDeserializer.java
+++ b/src/main/java/org/opensearch/cluster/etcd/ETCDStateDeserializer.java
@@ -258,7 +258,13 @@ public final class ETCDStateDeserializer {
             remoteShardAssignment.put(new Index(indexEntry.getKey(), uuid), shardAssignments);
         }
 
-        CoordinatorNodeState coordinatorNodeState = new CoordinatorNodeState(localNode, remoteNodes, remoteShardAssignment, aliases, remoteClusters);
+        CoordinatorNodeState coordinatorNodeState = new CoordinatorNodeState(
+            localNode,
+            remoteNodes,
+            remoteShardAssignment,
+            aliases,
+            remoteClusters
+        );
         return new NodeStateResult(coordinatorNodeState, keysToWatch);
     }
 

--- a/src/main/java/org/opensearch/cluster/etcd/ETCDStateDeserializer.java
+++ b/src/main/java/org/opensearch/cluster/etcd/ETCDStateDeserializer.java
@@ -185,6 +185,7 @@ public final class ETCDStateDeserializer {
     ) throws IOException {
         Map<String, Object> indices = (Map<String, Object>) remoteShards.get("indices");
         Map<String, Object> aliases = (Map<String, Object>) remoteShards.getOrDefault("aliases", new HashMap<>());
+        Map<String, Object> remoteClustersConfig = (Map<String, Object>) remoteShards.getOrDefault("remote_clusters", new HashMap<>());
         Set<String> remoteNodeNames = new HashSet<>();
 
         for (Map.Entry<String, Object> indexEntry : indices.entrySet()) {
@@ -202,6 +203,18 @@ public final class ETCDStateDeserializer {
         }
 
         Map<String, NodeHealthInfo> remoteNodeHealthMap = fetchNodeHealthInfo(etcdClient, remoteNodeNames, clusterName);
+
+        Map<String, Settings> remoteClusters = new HashMap<>();
+        for (Map.Entry<String, Object> entry : remoteClustersConfig.entrySet()) {
+            String alias = entry.getKey();
+            Map<String, Object> config = (Map<String, Object>) entry.getValue();
+            if (config.containsKey("seeds")) {
+                List<String> seeds = (List<String>) config.get("seeds");
+                String settingKey = "cluster.remote." + alias + ".seeds";
+                Settings remoteSettings = Settings.builder().putList(settingKey, seeds).build();
+                remoteClusters.put(alias, remoteSettings);
+            }
+        }
 
         List<String> keysToWatch = new ArrayList<>();
         boolean converged = true;
@@ -245,7 +258,7 @@ public final class ETCDStateDeserializer {
             remoteShardAssignment.put(new Index(indexEntry.getKey(), uuid), shardAssignments);
         }
 
-        CoordinatorNodeState coordinatorNodeState = new CoordinatorNodeState(localNode, remoteNodes, remoteShardAssignment, aliases);
+        CoordinatorNodeState coordinatorNodeState = new CoordinatorNodeState(localNode, remoteNodes, remoteShardAssignment, aliases, remoteClusters);
         return new NodeStateResult(coordinatorNodeState, keysToWatch);
     }
 

--- a/src/main/java/org/opensearch/cluster/etcd/changeapplier/CoordinatorNodeState.java
+++ b/src/main/java/org/opensearch/cluster/etcd/changeapplier/CoordinatorNodeState.java
@@ -30,17 +30,20 @@ public class CoordinatorNodeState extends NodeState {
     private final Collection<RemoteNode> remoteNodes;
     private final Map<Index, List<List<NodeShardAssignment>>> remoteShardAssignments;
     private final Map<String, Object> aliases;
+    private final Map<String, Settings> remoteClusters;
 
     public CoordinatorNodeState(
         DiscoveryNode localNode,
         Collection<RemoteNode> remoteNodes,
         Map<Index, List<List<NodeShardAssignment>>> remoteShardAssignments,
-        Map<String, Object> aliases
+        Map<String, Object> aliases,
+        Map<String, Settings> remoteClusters        
     ) {
         super(localNode);
         this.remoteNodes = remoteNodes;
         this.remoteShardAssignments = remoteShardAssignments;
         this.aliases = aliases;
+        this.remoteClusters = remoteClusters;
     }
 
     @Override
@@ -114,6 +117,14 @@ public class CoordinatorNodeState extends NodeState {
             nodesBuilder.add(remoteNode.toDiscoveryNode());
         }
 
+        if (this.remoteClusters != null && !this.remoteClusters.isEmpty()) {
+            Settings.Builder persistentSettingsBuilder = Settings.builder();
+            for (Settings remoteSetting : this.remoteClusters.values()) {
+                persistentSettingsBuilder.put(remoteSetting);
+            }
+            metadataBuilder.persistentSettings(persistentSettingsBuilder.build());
+        }
+        
         return ClusterState.builder(ClusterState.EMPTY_STATE)
             .nodes(nodesBuilder)
             .metadata(metadataBuilder)

--- a/src/main/java/org/opensearch/cluster/etcd/changeapplier/CoordinatorNodeState.java
+++ b/src/main/java/org/opensearch/cluster/etcd/changeapplier/CoordinatorNodeState.java
@@ -37,7 +37,7 @@ public class CoordinatorNodeState extends NodeState {
         Collection<RemoteNode> remoteNodes,
         Map<Index, List<List<NodeShardAssignment>>> remoteShardAssignments,
         Map<String, Object> aliases,
-        Map<String, Settings> remoteClusters        
+        Map<String, Settings> remoteClusters
     ) {
         super(localNode);
         this.remoteNodes = remoteNodes;
@@ -124,7 +124,7 @@ public class CoordinatorNodeState extends NodeState {
             }
             metadataBuilder.persistentSettings(persistentSettingsBuilder.build());
         }
-        
+
         return ClusterState.builder(ClusterState.EMPTY_STATE)
             .nodes(nodesBuilder)
             .metadata(metadataBuilder)


### PR DESCRIPTION
### Description
Add remote cluster and CCS support for CloudNative OpenSearch coordinator nodes

### Related Issues
Resolves #48 

### tests

etcd goalstate
```
{
  "remote_shards": {
    "remote_clusters": {"c1": {"seeds": ["127.0.0.1:9310"]}},
    "indices": {
      "myindex": {
        "shard_routing" : [
          [
            {"node_name": "integTest-1", "primary": true }
          ],
          [
            {"node_name": "integTest-2", "primary": true }
          ]
        ]
      }
    }
  }
}

```

CCS query and remote info

```
❯ curl http://127.0.0.1:9200/_remote/info | jq .
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   180  100   180    0     0    972      0 --:--:-- --:--:-- --:--:--   972
{
  "c1": {
    "connected": true,
    "mode": "sniff",
    "seeds": [
      "127.0.0.1:9310"
    ],
    "num_nodes_connected": 1,
    "max_connections_per_cluster": 3,
    "initial_connect_timeout": "30s",
    "skip_unavailable": false
  }
}
❯ curl http://127.0.0.1:9200/c1:idx1/_search | jq .
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   291  100   291    0     0   8566      0 --:--:-- --:--:-- --:--:--  8558
{
  "took": 22,
  "timed_out": false,
  "_shards": {
    "total": 1,
    "successful": 1,
    "skipped": 0,
    "failed": 0
  },
  "_clusters": {
    "total": 1,
    "successful": 1,
    "skipped": 0
  },
  "hits": {
    "total": {
      "value": 1,
      "relation": "eq"
    },
    "max_score": 1.0,
    "hits": [
      {
        "_index": "c1:idx1",
        "_id": "nJDMpZkBqVrZlhqyW6P8",
        "_score": 1.0,
        "_source": {
          "t": 1
        }
      }
    ]
  }
}
```

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
