### PR TITLE
Fix bug in ETCDWatcher cooldown logic

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,6 +18,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+    - uses: docker/setup-docker-action@v4
+    - name: Check Docker status
+       run: docker context ls && docker info
     - uses: actions/checkout@v6
     - name: Set up JDK ${{ matrix.java }}
       uses: actions/setup-java@v5


### PR DESCRIPTION
<!--  Thanks for sending a pull request, here are some tips:

1. If this is a fix for an undisclosed security vulnerability, please STOP. All security vulnerability reporting and fixes should be done as per our security policy https://github.com/opensearch-project/OpenSearch/security/policy
2. If this is your first time, please read our contributor guidelines: https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md and developer guide https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md
3. Ensure you have added or ran the appropriate tests for your PR: https://github.com/opensearch-project/OpenSearch/blob/main/TESTING.md
-->

### Description
Before this change, the logic was basically as follows:

1. When a change is detected, set the next pending action to apply that change. 
    Schedule a refresh after the cooldown. 
3. If more changes come in during that cooldown window, **but then stop
   before the cooldown expires**, the first scheduled task will apply the
   last change and clear the pending action. The remaining scheduled
   refreshes become no-ops.

So, we could handle a quick burst of updates but only applying the last one.

The problem is when there's a long period of changes. Let's say changes are coming in every millisecond continuously. The change that comes at time 0 schedules an update at time 100. That effectively skips updates 0-99, applying the update from time 100 (or time 99). The problem is that the task scheduled for change 1 runs at time 101 and applies the update from time 101 (or 100). All those delayed refreshes scheduled a millisecond apart are no longer no-ops, because there are new pending changes.

This change fixes that by only scheduling a refresh if there is no pending action. At the end of each action, we atomically check if we executed the last pending action. If not, we schedule another refresh in the future after the cooldown time.

Also, as discussed with @TejasNaikk, I've increased the cooldown time from 100 ms to 1 second.

### Related Issues
N/A

### Check List
- [x] Functionality includes testing.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md), if applicable.
- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose), if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
